### PR TITLE
Add multi‑arch Docker support and CI workflow enhancements (v0.3)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Git files
+.gitignore
+
+# Build artifacts
+build/
+output/
+docker-context/
+
+# GitHub Actions workflow files
+.github/
+
+# Local configuration or temporary files
+*.local
+*.swp
+*~
+
+# Aider files (keep existing if present)
+.aider*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,30 +6,32 @@ on:
         - '**'
 
 jobs:
-  build:
+  build-cross:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-cross-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
       with:
         submodules: true
+        fetch-depth: 0
     - name: Free up some space
-      run: | 
+      run: |
         rm --recursive --force '/opt' || true
     - name: Install dependencies
-      run: | 
-        sudo apt-get install --assume-yes golang-go
+      run: |
+        sudo apt-get update
+        sudo apt-get install --assume-yes golang-go jq
     - name: Setup Linux cross-compiler
-      run: | 
+      run: |
         declare -r SPHYNX_TAG="$(jq --raw-output '.tag_name' <<< "$(curl --connect-timeout '10' --retry '15' --retry-all-errors --fail --silent --url 'https://api.github.com/repos/AmanoTeam/Sphynx/releases/latest')")"
         declare -r SPHYNX_TARBALL='/tmp/toolchain.tar.xz'
         declare -r SPHYNX_URL="https://github.com/AmanoTeam/Sphynx/releases/download/${SPHYNX_TAG}/x86_64-unknown-linux-gnu.tar.xz"
-        
+
         curl --connect-timeout '10' --retry '15' --retry-all-errors --fail --silent --location --url "${SPHYNX_URL}" --output "${SPHYNX_TARBALL}"
         tar --directory="$(dirname "${SPHYNX_TARBALL}")" --extract --file="${SPHYNX_TARBALL}"
-        
+
         echo 'SPHYNX_HOME=/tmp/sphynx' >> "${GITHUB_ENV}"
         echo '/tmp/sphynx/bin' >> "${GITHUB_PATH}"
     - name: Setup Android cross-compiler
@@ -47,24 +49,24 @@ jobs:
         declare -r RAIDEN_TAG="$(jq --raw-output '.tag_name' <<< "$(curl --connect-timeout '10' --retry '15' --retry-all-errors --fail --silent --url 'https://api.github.com/repos/AmanoTeam/Raiden/releases/latest')")"
         declare -r RAIDEN_TARBALL='/tmp/toolchain.tar.xz'
         declare -r RAIDEN_URL="https://github.com/AmanoTeam/Raiden/releases/download/${RAIDEN_TAG}/x86_64-unknown-linux-gnu.tar.xz"
-        
+
         curl --connect-timeout '10' --retry '15' --retry-all-errors --fail --silent --location --url "${RAIDEN_URL}" --output "${RAIDEN_TARBALL}"
         tar --directory="$(dirname "${RAIDEN_TARBALL}")" --extract --file="${RAIDEN_TARBALL}"
-        
+
         echo 'RAIDEN_HOME=/tmp/raiden' >> "${GITHUB_ENV}"
         echo '/tmp/raiden/bin' >> "${GITHUB_PATH}"
     - name: Setup Tizen cross-compiler
-      run: | 
+      run: |
         declare -r NUL_TAG="$(jq --raw-output '.tag_name' <<< "$(curl --connect-timeout '10' --retry '15' --retry-all-errors --fail --silent --url 'https://api.github.com/repos/AmanoTeam/Nul/releases/latest')")"
         declare -r NUL_TARBALL='/tmp/toolchain.tar.xz'
         declare -r NUL_URL="https://github.com/AmanoTeam/Nul/releases/download/${NUL_TAG}/x86_64-unknown-linux-gnu.tar.xz"
-        
+
         curl --connect-timeout '10' --retry '15' --retry-all-errors --fail --silent --location --url "${NUL_URL}" --output "${NUL_TARBALL}"
         tar --directory="$(dirname "${NUL_TARBALL}")" --extract --file="${NUL_TARBALL}"
-        
+
         echo 'NUL_HOME=/tmp/nul' >> "${GITHUB_ENV}"
         echo '/tmp/nul/bin' >> "${GITHUB_PATH}"
-    - name: Build with CMake
+    - name: Build with CMake (Cross-Compile)
       run: |
         declare -r targets=(
             arm-tizenwearable-linux-gnueabi
@@ -88,54 +90,202 @@ jobs:
             x86_64-linux-gnu
             x86_64-unknown-linux-musl
         )
-        
+
         declare -r OUTPUT_DIRECTORY="$(realpath './output')"
-        
+
         mkdir --parent "${OUTPUT_DIRECTORY}"
         mkdir build && cd build
-        
+
         for target in "${targets[@]}"; do
             echo "Building for ${target}"
 
             declare KAD_ENABLE_LTO=ON
             declare OPENSSL_NO_ASM=OFF
-            
+
             if [[ "${target}" == arm-tizen* ]]; then
                 OPENSSL_NO_ASM=ON
             fi
-            
+
+            GO_EXEC_PATH=$(which go || echo '/usr/bin/go')
+
             cmake -Wno-dev \
                 -DKAD_ENABLE_LTO="${KAD_ENABLE_LTO}" \
-                -DCMAKE_TOOLCHAIN_FILE="./.github/workflows/cmake_toolchains/${target}.cmake" \
+                -DCMAKE_TOOLCHAIN_FILE="../.github/workflows/cmake_toolchains/${target}.cmake" \
                 -DCMAKE_INSTALL_PREFIX="${target}" \
                 -DPERL_EXECUTABLE='/usr/bin/perl' \
-                -DGO_EXECUTABLE='/usr/bin/go' \
+                -DGO_EXECUTABLE="${GO_EXEC_PATH}" \
                 -DOPENSSL_NO_ASM="${OPENSSL_NO_ASM}" \
-                -DCMAKE_BUILD_TYPE=MinSizeRel ../ 1>/dev/null
-            
+                -DCMAKE_BUILD_TYPE=MinSizeRel \
+                -DCMAKE_C_FLAGS_MINSIZEREL="-Os -Wno-error=unused-but-set-variable" \
+                -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os -Wno-error=unused-but-set-variable" \
+                -DCMAKE_SHARED_LINKER_FLAGS_MINSIZEREL="-Wl,-headerpad_max_install_names" \
+                -DCMAKE_EXE_LINKER_FLAGS_MINSIZEREL="-Wl,-headerpad_max_install_names" \
+                -DCMAKE_MODULE_LINKER_FLAGS_MINSIZEREL="-Wl,-headerpad_max_install_names" \
+                -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ../ 1>/dev/null
+
             cmake --build ./ -- --jobs 1>/dev/null
             cmake --install ./ 1>/dev/null
-                
-            tar --create --file=- "${target}" |  xz --compress -9 > "${OUTPUT_DIRECTORY}/${target}.tar.xz"
-            
+
+            mkdir -p "${OUTPUT_DIRECTORY}"
+            tar --create --file=- "${target}" | xz --compress -9 > "${OUTPUT_DIRECTORY}/${target}.tar.xz"
+
+            if [ ! -f "${OUTPUT_DIRECTORY}/${target}.tar.xz" ]; then
+                echo "Error: Failed to create ${OUTPUT_DIRECTORY}/${target}.tar.xz"
+                exit 1
+            fi
+
             rm --force --recursive ./*
         done
-    - name: Upload artifact
+    - name: Upload cross-compile artifact
       uses: actions/upload-artifact@main
       with:
+        name: cross-compile-output
         path: ./output
+
+  build-macos:
+    concurrency:
+      group: ${{ github.workflow }}-macos-${{ github.ref }}
+      cancel-in-progress: true
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@main
+      with:
+        submodules: true
+        fetch-depth: 0
+    - name: Install dependencies (Go)
+      env:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        HOMEBREW_NO_ENV_HINTS: 1
+      run: |
+        set -o pipefail
+        brew update || true
+        brew install --quiet go xz 2>&1 | grep -v '^Warning: These files were overwritten during the'
+    - name: Build with CMake (macOS arm64)
+      run: |
+        declare -r target="aarch64-apple-darwin"
+        declare -r OUTPUT_DIRECTORY="${GITHUB_WORKSPACE}/output" # Use absolute path
+
+        mkdir -p "${OUTPUT_DIRECTORY}" # Create using absolute path
+        mkdir build && cd build
+
+        echo "Building for ${target}"
+
+        declare KAD_ENABLE_LTO=OFF
+        declare GO_EXEC_PATH=$(which go)
+
+        cmake -Wno-dev \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DKAD_ENABLE_LTO="${KAD_ENABLE_LTO}" \
+            -DGO_EXECUTABLE="${GO_EXEC_PATH}" \
+            -DCMAKE_INSTALL_PREFIX="${target}" \
+            -DCMAKE_BUILD_TYPE=MinSizeRel \
+            -DCMAKE_C_FLAGS_MINSIZEREL="-Os -Wno-error=unused-but-set-variable" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ../
+
+        JOBS=4
+        echo "Using ${JOBS} parallel jobs for build"
+
+        chmod +x ../fixbuild.sh
+        ../fixbuild.sh ./ ${JOBS}
+
+        cmake --install ./
+
+        tar --create --file=- "${target}" | xz --compress -9 > "${OUTPUT_DIRECTORY}/${target}.tar.xz"
+
+        if [ ! -f "${OUTPUT_DIRECTORY}/${target}.tar.xz" ]; then
+            echo "Error: Failed to create ${OUTPUT_DIRECTORY}/${target}.tar.xz"
+            exit 1
+        fi
+
+    - name: Upload macOS artifact
+      uses: actions/upload-artifact@main
+      with:
+        name: macos-output
+        path: output
+        if-no-files-found: error
+
+  build-docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    needs: [build-cross] # Depends on cross-compilation artifacts
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docker' || startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@main
+        with:
+          submodules: recursive # Ensure recursive checkout for submodules
+          fetch-depth: 0 # Fetch all history for git operations if needed by build
+
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        id: buildx
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/kad
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha # Add SHA tag
+            type=raw,value=latest,enable={{is_default_branch}} # Add latest tag for default branch
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-cross, build-macos, build-docker]
+    if: startsWith(github.event.head_commit.message, 'Bump version')
+    steps:
     - name: Get tag name for release
-      if: startsWith(github.event.head_commit.message, 'Bump version')
-      run: echo "VERSION_TAG=${COMMIT_MESSAGE/* }" >> "${GITHUB_ENV}"
+      id: get_tag
+      run: echo "VERSION_TAG=${COMMIT_MESSAGE/* }" >> $GITHUB_OUTPUT
       env:
         COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+    - name: Download all artifacts
+      uses: actions/download-artifact@main
+      with:
+        path: release-assets
+    - name: Verify artifacts
+      run: |
+        for target in arm-tizenwearable-linux-gnueabi arm-tizenmobile-linux-gnueabi arm-tizeniot-linux-gnueabi arm-tizeniotheadless-linux-gnueabi arm-linux-gnueabi arm-linux-gnueabihf arm-unknown-linux-musleabihf armv7a-linux-androideabi aarch64-tizeniot-linux-gnu aarch64-linux-android aarch64-linux-gnu aarch64-unknown-linux-musl i386-tizenmobile-linux-gnueabi i386-tizenwearable-linux-gnueabi i386-unknown-linux-musl i686-linux-android i686-linux-gnu x86_64-linux-android x86_64-linux-gnu x86_64-unknown-linux-musl; do
+          if [ ! -f "release-assets/cross-compile-output/${target}.tar.xz" ]; then
+            echo "Error: Missing cross-compile artifact for ${target}"
+            exit 1
+          fi
+        done
+
+        if [ ! -f "release-assets/macos-output/aarch64-apple-darwin.tar.xz" ]; then
+          echo "Error: Missing macOS artifact"
+          exit 1
+        fi
     - name: Create release
-      if: startsWith(github.event.head_commit.message, 'Bump version')
       uses: softprops/action-gh-release@master
       with:
-        tag_name: v${{ env.VERSION_TAG }}
-        name: Kad v${{ env.VERSION_TAG }}
-        files: ./output/*
+        tag_name: v${{ steps.get_tag.outputs.VERSION_TAG }}
+        name: Kad v${{ steps.get_tag.outputs.VERSION_TAG }}
+        files: release-assets/**/*
         draft: true
         prerelease: false
         fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.aider*
+
+# Build artifacts
+build/
+output/
+docker-context/
+
+# Local configuration or temporary files
+*.local
+*.swp
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(
-	Kad
-	VERSION 0.2
+project(Kad
+	VERSION 0.3
 	DESCRIPTION "Kad is a simple HTTP proxy server that forwards all requests through curl-impersonate"
 	HOMEPAGE_URL "https://github.com/AmanoTeam/Kad"
 	LANGUAGES C
@@ -59,7 +58,7 @@ file(WRITE "${CMAKE_SOURCE_DIR}/submodules/zlib/CMakeLists.txt" "${FILE_CONTENTS
 
 if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/submodules/curl/.patched")
 	message("-- Patching cURL")
-	
+
 	execute_process(
 		COMMAND patch
 		--directory=${CMAKE_CURRENT_SOURCE_DIR}/submodules/curl
@@ -67,13 +66,13 @@ if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/submodules/curl/.patched")
 		--input=${CMAKE_CURRENT_SOURCE_DIR}/submodules/curl-impersonate/chrome/patches/curl-impersonate.patch
 		COMMAND_ERROR_IS_FATAL ANY
 	)
-	
+
 	file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/submodules/curl/.patched" "")
 endif()
 
 if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/submodules/boringssl/.patched")
 	message("-- Patching BoringSSL")
-	
+
 	execute_process(
 		COMMAND patch
 		--directory=${CMAKE_CURRENT_SOURCE_DIR}/submodules/boringssl
@@ -81,7 +80,7 @@ if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/submodules/boringssl/.patched")
 		--input=${CMAKE_CURRENT_SOURCE_DIR}/submodules/curl-impersonate/chrome/patches/boringssl-old-ciphers.patch
 		COMMAND_ERROR_IS_FATAL ANY
 	)
-	
+
 	file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/submodules/boringssl/.patched" "")
 endif()
 
@@ -156,11 +155,11 @@ foreach(target zlib crypto ssl nghttp2 brotlidec c-ares)
 		OUTPUT ${target}
 		COMMAND ${CMAKE_COMMAND} --build ./ --target ${target}
 	)
-	
+
 	add_custom_target(
 		"ensure_${target}" ALL DEPENDS "${target}"
 	)
-	
+
 	add_dependencies(
 		libcurl
 		"ensure_${target}"
@@ -495,7 +494,7 @@ add_executable(
 	src/threads.c
 )
 
-if (KAD_DISABLE_CERTIFICATE_VALIDATION) 
+if (KAD_DISABLE_CERTIFICATE_VALIDATION)
 	target_compile_definitions(
 		kad
 		PRIVATE
@@ -513,10 +512,10 @@ endif()
 
 if (KAD_ENABLE_LTO)
 	set(KAD_HAS_LTO OFF)
-	
+
 	include(CheckIPOSupported)
 	check_ipo_supported(RESULT KAD_HAS_LTO LANGUAGES C)
-	
+
 	if (KAD_HAS_LTO)
 		foreach(target kad bearssl libcurl zlib crypto ssl nghttp2 brotlicommon brotlidec c-ares)
 			set_target_properties(

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM debian:bookworm-slim AS builder
 
-WORKDIR /app
+FROM debian:bookworm AS builder
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -10,32 +9,54 @@ RUN apt-get update && \
     patch \
     ca-certificates \
     python3 \
-    golang-go && \
-    apt-get clean && \
+    golang-go \
+    xz-utils \
+    && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-COPY . .
-
-RUN git submodule update --init
-
-RUN cmake -B build -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/app/dist
-RUN cmake --build ./build
-RUN cmake --install ./build
-
-FROM debian:bookworm-slim
 
 WORKDIR /app
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+COPY .git .git
+COPY .gitmodules .gitmodules
 
-COPY --from=builder /app/dist /app
+RUN git submodule update --init --recursive
 
-ENV PATH="/app/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/app/lib"
+COPY . .
+
+RUN cmake -B build \
+    -DCMAKE_BUILD_TYPE=MinSizeRel \
+    -DCMAKE_INSTALL_PREFIX=/app/dist \
+    -DGO_EXECUTABLE=$(which go) \
+    -DPERL_EXECUTABLE='/usr/bin/perl' \
+    .
+
+RUN cmake --build ./build --parallel $(nproc)
+
+RUN cmake --install ./build
+
+FROM debian:bookworm-slim AS final
+
+RUN groupadd --gid 1001 kad && \
+    useradd --uid 1001 --gid 1001 --shell /bin/false --create-home kad
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder --chown=kad:kad /app/dist /app
+
+ENV LD_LIBRARY_PATH=/app/lib
+
+RUN chown -R kad:kad /app && \
+    chmod -R u=rwX,go=rX /app && \
+    find /app/bin -type f -exec chmod +x {} \;
+
+USER kad
 
 EXPOSE 4000
 
-CMD ["kad", "--host=0.0.0.0"]
+ENTRYPOINT ["/app/bin/kad"]
+
+CMD ["--host=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -26,24 +26,25 @@ cmake --install ./build
 
 ## Building and Running with Docker
 
-You can also build and run Kad using Docker.
+You can run Kad via Docker in two ways: pull the official image from Docker Hub, or build the image locally.
 
-1.  **Build the Docker image:**
+1.  **Pull and run the official image:**
     ```bash
-    docker build -t kad .
+    docker pull lukastsai/kad:latest
+    docker run --rm -p 4000:4000 lukastsai/kad:latest
     ```
 
-2.  **Run the container:**
+2.  **Build and run the Docker image locally:**
     ```bash
-    # This will run the proxy on port 4000 on your host machine
-    docker run -p 4000:4000 kad
+    docker build -t kad .
+    docker run --rm -p 4000:4000 kad
     ```
 
 ## Usage
 
 Available options:
 
-```
+```bash
 $ kad --help
 usage: kad [-h] [-v] [--host HOST] [--port PORT] [--target TARGET]
 
@@ -61,10 +62,9 @@ Note, options that take an argument require a equal sign. E.g. --host=HOST
 
 You can start a server with all default options by simply running `kad`:
 
-```
+```bash
 $ kad
 Starting server at http://127.0.0.1:4000 (pid = 478)
-
 ```
 
 ## Examples
@@ -111,4 +111,3 @@ To circumvent this, you need to disable SSL certificate validation in your HTTP 
 
 - Windows is not supported for now ([#1](https://github.com/AmanoTeam/Kad/issues/1))
 - Only supports impersonating Chrome, Edge and Safari
-

--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ cmake --build ./build
 cmake --install ./build
 ```
 
+## Building and Running with Docker
+
+You can also build and run Kad using Docker.
+
+1.  **Build the Docker image:**
+    ```bash
+    docker build -t kad .
+    ```
+
+2.  **Run the container:**
+    ```bash
+    # This will run the proxy on port 4000 on your host machine
+    docker run -p 4000:4000 kad
+    ```
+
 ## Usage
 
 Available options:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # Kad
 
+[![Build Status](https://github.com/iCross/Kad/actions/workflows/build.yml/badge.svg)](https://github.com/AmanoTeam/Kad/actions/workflows/build.yml)
+[![Docker Pulls](https://img.shields.io/docker/pulls/lukastsai/kad)](https://hub.docker.com/r/lukastsai/kad)
+
 Kad is a simple HTTP proxy server that forwards all requests through curl-impersonate.
 
 ## Installation
 
-You can obtain precompiled binaries from the [releases](https://github.com/AmanoTeam/Kad/releases) page.
+You can obtain precompiled binaries from the [releases](https://github.com/iCross/Kad/releases) page.
 
 ## Building
 
 Clone this repository and fetch all submodules
 
 ```bash
-git clone --depth='1' 'https://github.com/AmanoTeam/Kad.git'
+git clone --depth='1' 'https://github.com/iCross/Kad.git'
 cd Kad
 git submodule update --init --depth='1'
 ```

--- a/fixbuild.sh
+++ b/fixbuild.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+BUILD_DIR=${1:-"build"}
+cd "$BUILD_DIR" || exit 1
+
+JOBS=${2:-4}
+
+echo "Starting build with -j${JOBS} parallel jobs..."
+cmake --build . --verbose -- -j${JOBS} || true
+
+find . -name link.txt -type f | while read -r file; do
+  if grep -q -- "-static-libgcc\|-static-libstdc++" "$file"; then
+    echo "Fixing $file..."
+    sed -i '' -E 's/-static-libgcc[[:space:]]*//g; s/-static-libstdc\+\+[[:space:]]*//g' "$file"
+  fi
+done
+
+echo "Continuing build with -j${JOBS} parallel jobs..."
+cmake --build . --verbose -- -j${JOBS}

--- a/src/kad.h
+++ b/src/kad.h
@@ -1,7 +1,7 @@
 #include "program_help.h"
 
 static const char KAD_NAME[] = "Kad";
-static const char KAD_VERSION[] = "0.1";
+static const char KAD_VERSION[] = "0.3";
 static const char KAD_REPOSITORY[] = "https://github.com/AmanoTeam/Kad";
 
 static const char KAD_DESCRIPTION[] = PROGRAM_HELP;


### PR DESCRIPTION
## What

This PR overhauls the build and release infrastructure in preparation for v0.3:

- **Docker**  
  - Introduce a `.dockerignore` to slim down build context.  
  - Rewrite `Dockerfile` into a multi‐stage build, optimize apt installs, submodule init, and properly set user, permissions, `ENTRYPOINT` and `CMD`.  
- **GitHub Actions**  
  - Rename and restructure the primary build job (`build-cross`) to install necessary tools (`jq`), fetch full git history, and cross‑compile for a wide array of Linux targets.  
  - Add a new **macOS arm64** job to build on M1.  
  - Add a **build-docker** job leveraging Buildx to push multi‑architecture images (`amd64`, `arm64`, `arm/v7`, `arm/v6`, `ppc64le`).  
- **Source tree**  
  - New `fixbuild.sh` helper to strip problematic static flags on macOS.  
  - Bump project version to **0.3** in `CMakeLists.txt` and `src/kad.h`.  
  - Add `.gitignore` entries for build/output artifacts and temp files.  
- **Docs**  
  - Update `README.md` with Docker build/run instructions.

## Why

- Provide first‑class Docker support for local development and CI.  
- Ensure consistent cross‐platform binaries across Linux and macOS M1.  
- Clean up legacy comments and streamline the build process.  
- Prepare for the v0.3 release.

## Verification

- ✅ Local CMake build on Linux & macOS arm64  
- ✅ Cross‑compile artifacts produced for all declared targets  
- ✅ Docker multi‑arch image publishes successfully via Buildx  
- ✅ Tests (if any) pass unchanged  

_No functional changes to the runtime code, only build/configuration improvements._